### PR TITLE
BUG27434751: Add a TLS/SSL option to verify server name

### DIFF
--- a/lib/mysql/connector/abstracts.py
+++ b/lib/mysql/connector/abstracts.py
@@ -323,6 +323,9 @@ class MySQLConnectionAbstract(object):
             if 'verify_cert' not in self._ssl:
                 self._ssl['verify_cert'] = \
                     DEFAULT_CONFIGURATION['ssl_verify_cert']
+            if 'verify_identity' not in self._ssl:
+                self._ssl['verify_identity'] = \
+                    DEFAULT_CONFIGURATION['ssl_verify_identity']
             # Make sure both ssl_key/ssl_cert are set, or neither (XOR)
             if 'ca' not in self._ssl or self._ssl['ca'] is None:
                 raise AttributeError(

--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -131,7 +131,13 @@ class MySQLConnection(MySQLConnectionAbstract):
             packet = self._protocol.make_auth_ssl(charset=charset,
                                                   client_flags=client_flags)
             self._socket.send(packet)
-            self._socket.switch_to_ssl(**ssl_options)
+            self._socket.switch_to_ssl(ssl_options.get('ca'),
+                                       ssl_options.get('cert'),
+                                       ssl_options.get('key'),
+                                       ssl_options.get('verify_cert') or False,
+                                       ssl_options.get('verify_identity') or False,
+                                       ssl_options.get('cipher'),
+                                       ssl_options.get('version', None))
             self._ssl_active = True
 
         packet = self._protocol.make_auth(

--- a/lib/mysql/connector/connection_cext.py
+++ b/lib/mysql/connector/connection_cext.py
@@ -140,7 +140,7 @@ class CMySQLConnection(MySQLConnectionAbstract):
 
     def _open_connection(self):
         charset_name = CharacterSet.get_info(self._charset_id)[0]
-        self._cmysql = _mysql_connector.MySQL(  # pylint: disable=E1101
+        self._cmysql = _mysql_connector.MySQL(  # pylint: disable=E1101,I1101
             buffered=self._buffered,
             raw=self._raw,
             charset_name=charset_name,
@@ -161,10 +161,13 @@ class CMySQLConnection(MySQLConnectionAbstract):
 
         if self.isset_client_flag(ClientFlag.SSL):
             cnx_kwargs.update({
-                'ssl_ca': self._ssl['ca'],
-                'ssl_cert': self._ssl['cert'],
-                'ssl_key': self._ssl['key'],
-                'ssl_verify_cert': self._ssl['verify_cert']
+                'ssl_ca': self._ssl.get('ca'),
+                'ssl_cert': self._ssl.get('cert'),
+                'ssl_key': self._ssl.get('key'),
+                'ssl_verify_cert': self._ssl.get('verify_cert') or False,
+                'ssl_verify_identity':
+                    self._ssl.get('verify_identity') or False,
+                'ssl_disabled': self._ssl_disabled
             })
 
         try:

--- a/lib/mysql/connector/constants.py
+++ b/lib/mysql/connector/constants.py
@@ -56,6 +56,7 @@ DEFAULT_CONFIGURATION = {
     'ssl_cert': None,
     'ssl_key': None,
     'ssl_verify_cert': False,
+    'ssl_verify_identity': False,
     'ssl_cipher': None,
     'passwd': None,
     'db': None,

--- a/lib/mysql/connector/network.py
+++ b/lib/mysql/connector/network.py
@@ -168,7 +168,7 @@ class BaseMySQLSocket(object):
                 tmpbuf = bytearray()
                 for pkt in pkts:
                     tmpbuf += pkt
-                tmpbuf = buffer(tmpbuf)  # pylint: disable=E0602,R0204
+                tmpbuf = buffer(tmpbuf)  # pylint: disable=E0602
             else:
                 tmpbuf = b''.join(pkts)  # pylint: disable=R0204
             del pkts
@@ -403,7 +403,8 @@ class BaseMySQLSocket(object):
         self._connection_timeout = timeout
 
     # pylint: disable=C0103
-    def switch_to_ssl(self, ca, cert, key, verify_cert=False, cipher=None):
+    def switch_to_ssl(self, ca, cert, key, verify_cert=False,
+                      verify_identity=False, cipher=None, ssl_version=None):
         """Switch the socket to use SSL"""
         if not self.sock:
             raise errors.InterfaceError(errno=2048)
@@ -419,12 +420,16 @@ class BaseMySQLSocket(object):
                 cert_reqs=cert_reqs, do_handshake_on_connect=False,
                 ssl_version=ssl.PROTOCOL_TLSv1, ciphers=cipher)
             self.sock.do_handshake()
+            if verify_identity:
+                ssl.match_hostname(self.sock.getpeercert(), self.server_host)
         except NameError:
             raise errors.NotSupportedError(
                 "Python installation has no SSL support")
         except (ssl.SSLError, IOError) as err:
             raise errors.InterfaceError(
                 errno=2055, values=(self.get_address(), _strioerror(err)))
+        except ssl.CertificateError as err:
+            raise errors.InterfaceError(str(err))
         except NotImplementedError as err:
             raise errors.InterfaceError(str(err))
 


### PR DESCRIPTION
To prevent man-in-the-middle attacks, MySQL clients should connect using TLS
and verify the server name against the server certificate's common name (CN)
and subject alternative names (SANs).

This patch adds a new connection option `ssl_verify_identity` to perform this
verification in the pure Python implementation, and also changes the behavior
of the C extension implementation, which previously was performing this
verification by default.

A test was added for regression.

(cherry picked from commit 069bc6737dd13b7f3a41d7fc23b789b659d8e205)